### PR TITLE
[platform_tests][api] Add hardware revision test case to chassis and psu

### DIFF
--- a/tests/common/helpers/platform_api/chassis.py
+++ b/tests/common/helpers/platform_api/chassis.py
@@ -37,6 +37,10 @@ def get_serial(conn):
     return chassis_api(conn, 'get_serial')
 
 
+def get_revision(conn):
+    return chassis_api(conn, 'get_revision')
+
+
 def get_status(conn):
     return chassis_api(conn, 'get_status')
 

--- a/tests/common/helpers/platform_api/psu.py
+++ b/tests/common/helpers/platform_api/psu.py
@@ -39,6 +39,10 @@ def get_serial(conn, index):
     return psu_api(conn, index, 'get_serial')
 
 
+def get_revision(conn, index):
+    return psu_api(conn, index, 'get_revision')
+
+
 def get_status(conn, index):
     return psu_api(conn, index, 'get_status')
 

--- a/tests/platform_tests/api/test_chassis.py
+++ b/tests/platform_tests/api/test_chassis.py
@@ -128,6 +128,12 @@ class TestChassisApi(PlatformApiTestBase):
         pytest_assert(isinstance(serial, STRING_TYPE), "Chassis serial number appears incorrect")
         self.compare_value_with_device_facts(duthost, 'serial', serial)
 
+    def test_get_serial(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+        duthost = duthosts[enum_rand_one_per_hwsku_hostname]
+        revision = chassis.get_revision(platform_api_conn)
+        pytest_assert(revision is not None, "Unable to retrieve chassis serial number")
+        pytest_assert(isinstance(revision, STRING_TYPE), "Chassis serial number appears incorrect")
+
     def test_get_status(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
         status = chassis.get_status(platform_api_conn)
         pytest_assert(status is not None, "Unable to retrieve chassis status")

--- a/tests/platform_tests/api/test_chassis.py
+++ b/tests/platform_tests/api/test_chassis.py
@@ -128,7 +128,7 @@ class TestChassisApi(PlatformApiTestBase):
         pytest_assert(isinstance(serial, STRING_TYPE), "Chassis serial number appears incorrect")
         self.compare_value_with_device_facts(duthost, 'serial', serial)
 
-    def test_get_serial(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+    def test_get_revision(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
         duthost = duthosts[enum_rand_one_per_hwsku_hostname]
         revision = chassis.get_revision(platform_api_conn)
         pytest_assert(revision is not None, "Unable to retrieve chassis serial number")

--- a/tests/platform_tests/api/test_psu.py
+++ b/tests/platform_tests/api/test_psu.py
@@ -102,6 +102,13 @@ class TestPsuApi(PlatformApiTestBase):
                 self.expect(isinstance(serial, STRING_TYPE), "PSU {} serial number appears incorrect".format(i))
         self.assert_expectations()
 
+    def test_get_revision(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+        for i in range(self.num_psus):
+            revision = psu.get_revision(platform_api_conn, i)
+            if self.expect(revision is not None, "Unable to retrieve PSU {} serial number".format(i)):
+                self.expect(isinstance(revision, STRING_TYPE), "PSU {} serial number appears incorrect".format(i))
+        self.assert_expectations()
+
     def test_get_status(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
         for i in range(self.num_psus):
             status = psu.get_status(platform_api_conn, i)


### PR DESCRIPTION
### Description of PR
Adds tests cases to validate the existence of hardware revision for chassis and psu devices. 

### Type of change

- [ ] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
We recently defined the hardware revision API and implemented it on Mellanox platforms. We now desire to add testing to verify that this platform API implementation remains stable so it may be relied upon in other areas of code. 

#### How did you do it?
Used the same method as in other api tests such as `get_serial()` and `get_model()` for both devices. 
