### PR TITLE
[platform][api] Skip model and serial PSU tests on mellanox platform

### DIFF
--- a/tests/common/utilities.py
+++ b/tests/common/utilities.py
@@ -24,12 +24,16 @@ logger = logging.getLogger(__name__)
 cache = FactsCache()
 
 
-def skip_version(duthost, version_list):
+def skip_version(duthost, version_list, platform=None):
     """
     @summary: Skip current test if any given version keywords are in os_version
     @param duthost: The DUT
     @param version_list: A list of incompatible versions
+    @param platforms: Optional argument to specify platform this directive is applicable to
     """
+    if platform and duthost.facts["asic_type"] != platform
+        return # Not applicable to this platform
+
     if any(version in duthost.os_version for version in version_list):
         pytest.skip("DUT has version {} and test does not support {}".format(duthost.os_version, ", ".join(version_list)))
 

--- a/tests/platform_tests/api/test_psu.py
+++ b/tests/platform_tests/api/test_psu.py
@@ -90,6 +90,7 @@ class TestPsuApi(PlatformApiTestBase):
         self.assert_expectations()
 
     def test_get_model(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+        skip_version(duthost, ["201811", "201911", "202012"], platform="mellanox")
         for i in range(self.num_psus):
             model = psu.get_model(platform_api_conn, i)
             if self.expect(model is not None, "Unable to retrieve PSU {} model".format(i)):
@@ -97,6 +98,7 @@ class TestPsuApi(PlatformApiTestBase):
         self.assert_expectations()
 
     def test_get_serial(self, duthosts, enum_rand_one_per_hwsku_hostname, localhost, platform_api_conn):
+        skip_version(duthost, ["201811", "201911", "202012"], platform="mellanox")
         for i in range(self.num_psus):
             serial = psu.get_serial(platform_api_conn, i)
             if self.expect(serial is not None, "Unable to retrieve PSU {} serial number".format(i)):


### PR DESCRIPTION
### Description of PR
Skips the `test_serial` and `test_model` tests in `test_psu` under the platform api tests for the mellanox platform when the SONiC version is less than 202106. 

Added platform awareness to `skip_version` so that this function could be used for this functionality. This allows for concise and maintainable skipping of tests for certain versions on certain platforms.  

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [x] Test case(new/improvement)

### Approach
#### What is the motivation for this PR?
These tests are failing on the mellanox platform because the specific API implementations they test were not implemented for mellanox on SONiC versions prior to 202106

#### How did you do it?
Used dut facts 'asic' to test if test is running on mellanox platform and augmented existing `skip_version` function in common utilities. 

#### How did you verify/test it?
Run test on mellanox platform and verify it skips if the SONiC version is 202012

#### Any platform specific information?
See above. Change only applicable to mellanox platform. 

#### Supported testbed topology if it's a new test case?
N/A Platform Test

### Documentation 
N/A No new document-able features
